### PR TITLE
Update Sagemaker Domain resources selectively

### DIFF
--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -82,12 +82,14 @@ func ResourceDomain() *schema.Resource {
 						"security_groups": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							ForceNew: true,
 							MaxItems: 5,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"execution_role": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: verify.ValidARN,
 						},
 						"sharing_settings": {
@@ -118,7 +120,6 @@ func ResourceDomain() *schema.Resource {
 						"tensor_board_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -157,7 +158,6 @@ func ResourceDomain() *schema.Resource {
 						"jupyter_server_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -204,7 +204,6 @@ func ResourceDomain() *schema.Resource {
 						"kernel_gateway_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -411,7 +410,7 @@ func resourceDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("default_user_settings") {
 		input := &sagemaker.UpdateDomainInput{
 			DomainId:            aws.String(d.Id()),
-			DefaultUserSettings: expandSagemakerDomainDefaultUserSettings(d.Get("default_user_settings").([]interface{})),
+			DefaultUserSettings: expandSagemakerDomainDefaultUserSettings(d),
 		}
 
 		log.Printf("[DEBUG] sagemaker domain update config: %#v", *input)
@@ -477,7 +476,8 @@ func expandSagemakerRetentionPolicy(l []interface{}) *sagemaker.RetentionPolicy 
 	return config
 }
 
-func expandSagemakerDomainDefaultUserSettings(l []interface{}) *sagemaker.UserSettings {
+func expandSagemakerDomainDefaultUserSettings(d *schema.ResourceData) *sagemaker.UserSettings {
+	l := d.Get("default_user_settings").([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -490,7 +490,7 @@ func expandSagemakerDomainDefaultUserSettings(l []interface{}) *sagemaker.UserSe
 		config.ExecutionRole = aws.String(v)
 	}
 
-	if v, ok := m["security_groups"].(*schema.Set); ok && v.Len() > 0 {
+	if v, ok := m["security_groups"].(*schema.Set); ok && v.Len() > 0 && d.HasChange("default_user_settings") {
 		config.SecurityGroups = flex.ExpandStringSet(v)
 	}
 

--- a/internal/service/sagemaker/user_profile.go
+++ b/internal/service/sagemaker/user_profile.go
@@ -101,7 +101,6 @@ func ResourceUserProfile() *schema.Resource {
 						"tensor_board_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -140,7 +139,6 @@ func ResourceUserProfile() *schema.Resource {
 						"jupyter_server_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -187,7 +185,6 @@ func ResourceUserProfile() *schema.Resource {
 						"kernel_gateway_app_settings": {
 							Type:     schema.TypeList,
 							Optional: true,
-							ForceNew: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Sagemaker supports live updates in some of the default user values
this allows for those values to be updated without recreation

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
